### PR TITLE
set value when no streaming is selected

### DIFF
--- a/octoprint_deploy.sh
+++ b/octoprint_deploy.sh
@@ -874,6 +874,7 @@ prepare () {
                         break
                     ;;
                     "None")
+                        VID=3
                         break
                     ;;
                     *) echo "invalid option $REPLY";;


### PR DESCRIPTION
Previously, the script emits errors as the VID is not valuated, so associated tests are syntactically incorrect.