### PR TITLE
Double slashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ These files provide a bash script for quickly deploying multiple octoprint insta
   * Change udev rules for an instance with `sudo octoprint_deploy/octoprint_deploy.sh replace`
   * Always a good idea to update octoprint_deploy from time-to-time with `git -C octoprint_deploy pull`
 # Recent Changes
+* Check for spaces in instance name, admin user, and password
 * Force camera port to be greater than 7000
 * Allow removal of individual camera services. Improvements to instance and camera removal.
 * Haproxy fixed! No more trailing slash required! Running new octoprint_deploy on an older installation automatically update these entries.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Updated April 6, 2023.  
+Updated April 15, 2023.  
 Want to support this work? Buy Me a Coffee. https://www.buymeacoffee.com/ppaukstelis.
 Need help with octoprint_deploy? Ask on Discord: https://discord.gg/6vgSjgvR6u
 # octoprint_deploy
@@ -60,6 +60,7 @@ These files provide a bash script for quickly deploying multiple octoprint insta
   * Change udev rules for an instance with `sudo octoprint_deploy/octoprint_deploy.sh replace`
   * Always a good idea to update octoprint_deploy from time-to-time with `git -C octoprint_deploy pull`
 # Recent Changes
+* Remove path double slashes that seemed to prevented deletion of timelapse videos.
 * Check for spaces in instance name, admin user, and password
 * Force camera port to be greater than 7000
 * Allow removal of individual camera services. Improvements to instance and camera removal.

--- a/octoprint_deploy.sh
+++ b/octoprint_deploy.sh
@@ -108,7 +108,7 @@ new_instance () {
         echo Selected port is: $PORT | log
         OCTOUSER=$user
         OCTOPATH=$DAEMONPATH
-        OCTOCONFIG="/home/$user/"
+        OCTOCONFIG="/home/$user"
         BFOLD="/home/$user/.octoprint"
         echo "Your OctoPrint instance will be installed at /home/$user/.$INSTANCE"
         echo
@@ -158,7 +158,7 @@ new_instance () {
         echo "Octoprint Config Path (where the hidden instance directory will be) [/home/$user/]:"
         read OCTOCONFIG
         if [ -z "$OCTOCONFIG" ]; then
-            OCTOCONFIG="/home/$user/"
+            OCTOCONFIG="/home/$user"
         fi
         
         #octoprint_base is the generic .octoprint folder that contains all configuration, upload, etc.

--- a/octoprint_deploy.sh
+++ b/octoprint_deploy.sh
@@ -1424,7 +1424,7 @@ instance_status() {
 }
 
 main_menu() {
-    VERSION=0.2.3
+    VERSION=0.2.4
     #reset
     UDEV=''
     TEMPUSB=''


### PR DESCRIPTION
Remove double slashes in service files. The native OctoPrint file deletion seemed to fail for timelapses.