### PR TITLE
Fix octoprint errors when trying to share uploads

### DIFF
--- a/util.sh
+++ b/util.sh
@@ -172,9 +172,9 @@ share_uploads() {
         fi
         echo
         #Remove Quit and Custom from array, is there a cleaner way?
-        unset 'options[-1]'
-        unset 'options[-1]'
-        for instance in "${options[@]}"; do
+        unset 'INSTANCE_ARR[-1]'
+        unset 'INSTANCE_ARR[-1]'
+        for instance in "${INSTANCE_ARR[@]}"; do
             $OCTOEXEC --basedir /home/$user/.$instance config set folder.uploads "$opt"
         done
         break


### PR DESCRIPTION
Incorrect variables were causing the octoprint command to take the options from the previous menu:
```
*************************
octoprint_deploy 1.0.5
*************************

1) Add instance	    3) Add Camera	5) Utilities	    7) Update
2) Delete instance  4) Delete Camera	6) Backup Menu	    8) Quit
Select operation: 5


1) Instance Status    4) Share Uploads	    7) Udev Menu
2) USB Port Testing   5) Change Streamer    8) Diagnostic Output
3) Sync Users	      6) Set Global Config  9) Quit
Select an option: 4


This option will make all your uploads go to a single instance.
This will mean all gcode files be available for all your instances.
Use this option only if you understand the implications.
This can be adjusted later in the Folders settings of OctoPrint.
1) octoprint  3) printer3   5) Custom
2) printer2   4) printer4   6) Quit
Select instance where uploads will be stored: 1

Usage: octoprint [OPTIONS] COMMAND [ARGS]...
Try 'octoprint --help' for help.

Error: No such command 'Status'.
Usage: octoprint [OPTIONS] COMMAND [ARGS]...
Try 'octoprint --help' for help.

Error: No such command 'Port'.
Usage: octoprint [OPTIONS] COMMAND [ARGS]...
Try 'octoprint --help' for help.

Error: No such command 'Users'.
Usage: octoprint [OPTIONS] COMMAND [ARGS]...
Try 'octoprint --help' for help.

Error: No such command 'Uploads'.
Usage: octoprint [OPTIONS] COMMAND [ARGS]...
Try 'octoprint --help' for help.

Error: No such command 'Streamer'.
Usage: octoprint [OPTIONS] COMMAND [ARGS]...
Try 'octoprint --help' for help.

Error: No such command 'Global'.
Usage: octoprint [OPTIONS] COMMAND [ARGS]...
Try 'octoprint --help' for help.

Error: No such command 'Menu'.
Instances must be restarted for changes to take effect.```