### PR TITLE
Move to native backup system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 
 
-Updated January 15, 2024.  
+Updated January 19, 2024.  
 
 Want to support this work? Buy Me a Coffee. https://www.buymeacoffee.com/ppaukstelis.
 Need help with octoprint_deploy? Ask on Discord: https://discord.gg/6vgSjgvR6u
-# octoprint_deploy 1.0.4 - ALL NEW
+# octoprint_deploy 1.0.7
 
 * These files provide a bash script for quickly deploying multiple octoprint instances on a single computer. For Linux systems (Ubuntu, Fedora, etc.) it will also install OctoPrint and a video streamer (ustreamer). No need for lots of file editing or complicated Docker compose scripts! A background video on how it generally works from my ERRF2022 talk can be found here: https://www.youtube.com/watch?v=q0iCNl8-kJI&t=15378s
 * octoprint_deploy and octoprint_install are being merged! Maintaining two separate scripts was close to twice the amount of work. By merging the scripts many new features have been included, while also providing greater simplicity in setup. 
@@ -62,7 +62,8 @@ Need help with octoprint_deploy? Ask on Discord: https://discord.gg/6vgSjgvR6u
   * Restart all instances from the command line: `sudo octoprint_deploy/octoprint_deploy.sh restart_all`
   * You can inject any function at start using the command line with the first argument `f` and the second argument the function name. 
 # Recent Changes
-  * Remove octoprint_deploy backups and move entirely to native OctoPrint backups
+  * Improve Instance Status function.
+  * Remove octoprint_deploy backup technique and move entirely to native OctoPrint backups. Backups made in this way are moved to /home/$USER/instance_backup to make them easier to sort.
   * Fixes for shared uploads function.
   * Command-line function injection. Will be useful in some cases.
   * Allow first instance creation without udev rule

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Need help with octoprint_deploy? Ask on Discord: https://discord.gg/6vgSjgvR6u
   * Restart all instances from the command line: `sudo octoprint_deploy/octoprint_deploy.sh restart_all`
   * You can inject any function at start using the command line with the first argument `f` and the second argument the function name. 
 # Recent Changes
+  * Remove octoprint_deploy backups and move entirely to native OctoPrint backups
   * Fixes for shared uploads function.
   * Command-line function injection. Will be useful in some cases.
   * Allow first instance creation without udev rule

--- a/instance.sh
+++ b/instance.sh
@@ -124,7 +124,7 @@ new_instance() {
     
     #USB cameras
     if [ "$firstrun" != "true" ]; then
-        if prompt_confirm "Would you like to auto detect an associated USB camera (experimental)?"; then
+        if prompt_confirm "Would you like to auto detect an associated USB camera?"; then
             add_camera
         fi
     fi

--- a/menu.sh
+++ b/menu.sh
@@ -251,7 +251,7 @@ restore_menu() {
         
         echo "Selected instance to restore: $opt"
     
-    
+    clear
     PS3="${green}Select backup to restore: ${white}"
     readarray -t options < <(ls /home/$user/instance_backup/$opt-backup-*.zip)
     options+=("Quit")

--- a/menu.sh
+++ b/menu.sh
@@ -250,7 +250,7 @@ restore_menu() {
         fi
         
         echo "Selected instance to restore: $opt"
-    done
+    
     
     PS3="${green}Select backup to restore: ${white}"
     readarray -t options < <(ls /home/$user/instance_backup/$opt-backup-*.zip)
@@ -264,5 +264,6 @@ restore_menu() {
         echo "Selected $opt to restore"
         restore $opt /home/$user/instance_backup/$zipfile
         main_menu
+    done
     done
 }

--- a/menu.sh
+++ b/menu.sh
@@ -262,7 +262,7 @@ restore_menu() {
         fi
         
         echo "Selected $opt to restore"
-        restore $opt /home/$user/instance_backup/$zipfile
+        restore $opt $zipfile
         main_menu
     done
     done

--- a/menu.sh
+++ b/menu.sh
@@ -8,7 +8,7 @@ cyan=$(echo -en "\e[96m")
 yellow=$(echo -en "\e[93m") 
 
 main_menu() {
-    VERSION=1.0.5
+    VERSION=1.0.7
     #reset
     UDEV=''
     TEMPUSB=''
@@ -240,18 +240,29 @@ create_menu() {
 
 restore_menu() {
     echo
-    echo
-    PS3="${green}Select backup to restore: ${white}"
-    readarray -t options < <(ls /home/$user/*.tar.gz)
-    options+=("Quit")
-    select opt in "${options[@]}"
+    echo "${magenta}You must have already created an instance in order to restore it.${white}"
+    PS3="${green}Select instance to restore: ${white}"
+    get_instances true
+    select opt in "${INSTANCE_ARR[@]}"
     do
-        if [ "$opt" == Quit ] || [ "$opt" == generic ]; then
+        if [ "$opt" == Quit ]; then
+            main_menu
+        fi
+        
+        echo "Selected instance to restore: $opt"
+    done
+    
+    PS3="${green}Select backup to restore: ${white}"
+    readarray -t options < <(ls /home/$user/instance_backup/$opt-backup-*.zip)
+    options+=("Quit")
+    select zipfile in "${options[@]}"
+    do
+        if [ "$zipfile" == Quit ]; then
             main_menu
         fi
         
         echo "Selected $opt to restore"
-        tar --same-owner -pxvf $opt
+        restore $opt /home/$user/instance_backup/$zipfile
         main_menu
     done
 }

--- a/prepare.sh
+++ b/prepare.sh
@@ -22,7 +22,7 @@ detect_installs() {
         echo "This will make sure the correct printer is associated with each OctoPrint instance."
         echo "This can also be done in the Utility menu at a later time."
         get_settings
-        if prompt_confirm "${green}Would you like to generate a udev rule now?{$white}"; then
+        if prompt_confirm "${green}Would you like to generate a udev rule now?${white}"; then
             echo "Unplug your printer from the USB connection now."
             if prompt_confirm "${green}Ready to begin printer auto-detection?${white}"; then
                 detect_printer

--- a/util.sh
+++ b/util.sh
@@ -60,9 +60,10 @@ octo_deploy_update() {
 back_up() {
     INSTANCE=$1
     echo "Creating backup of $INSTANCE...."
-    d=$(date '+%Y-%m-%d')
-    sudo -p $user tar -czf ${INSTANCE}_${d}_backup.tar.gz -C /home/$user/ .${INSTANCE}
-    echo "Tarred and gzipped backup created in /home/$user"
+    sudo -p $user $OCTOEXEC --basedir /home/$user/.$INSTANCE plugins backup:backup --exclude timelapse
+    sudo -p $user mkdir /home/$user/instance_backup 2>/dev/null
+    mv /home/$user/.$INSTANCE/data/backup/*.zip /home/$user/isntance_backup
+    echo "Zipped instance backup created in /home/$user/instance_backup"
 }
 
 restore() {
@@ -70,7 +71,7 @@ restore() {
     TAR=$2
     echo "Restoring backup of $INSTANCE...."
     systemctl stop $INSTANCE
-    sudo -p $user tar -xvf $TAR
+    sudo -p $user $OCTOEXEC --basedir /home/$user/.$INSTANCE plugins backup:restore $TAR
     systemctl start $INSTANCE
     
 }
@@ -78,7 +79,7 @@ restore() {
 back_up_all() {
     get_settings
     get_instances false
-    for instance in "${instances[@]}"; do
+    for instance in "${INSTANCE_ARR[@]}"; do
         echo $instance
         back_up $instance
     done

--- a/util.sh
+++ b/util.sh
@@ -272,9 +272,11 @@ instance_status() {
     echo
     echo "${cyan}*******************************************${white}"
     get_instances false
-    readarray -t cameras < <(ls -1 /etc/systemd/system/cam*.service 2> /dev/null | sed -n -e 's/^.*\/\(.*\).service/\1/p')
+    get_cameras
+    #change this to reading /etc/octoprint_cameras
+    #readarray -t cameras < <(ls -1 /etc/systemd/system/cam*.service 2> /dev/null | sed -n -e 's/^.*\/\(.*\).service/\1/p')
     #combine instances and cameras
-    INSTANCE_ARR+=(${cameras[@]})
+    INSTANCE_ARR+=(${CAMERA_ARR[@]})
     echo "Service - Status:"
     echo "------------------"
     for instance in "${INSTANCE_ARR[@]}"; do

--- a/util.sh
+++ b/util.sh
@@ -88,17 +88,21 @@ back_up_all() {
 
 get_instances() {
     addquit=$1
-    readarray -t INSTANCE_ARR < <(cat /etc/octoprint_instances | sed -n -e 's/^instance:\([[:graph:]]*\) .*/\1/p')
-    if [ "$addquit" == true ]; then
-        INSTANCE_ARR+=("Quit")
+    if [ -f /etc/octoprint_instances ]; then
+        readarray -t INSTANCE_ARR < <(cat /etc/octoprint_instances | sed -n -e 's/^instance:\([[:graph:]]*\) .*/\1/p')
+        if [ "$addquit" == true ]; then
+            INSTANCE_ARR+=("Quit")
+        fi
     fi
 }
 
 get_cameras() {
     addquit=$1
-    readarray -t CAMERA_ARR < <(cat /etc/octoprint_cameras | sed -n -e 's/^camera:\([[:graph:]]*\) .*/\1/p')
-    if [ "$addquit" == true ]; then
+    if [ -f /etc/octoprint_cameras ]; then
+        readarray -t CAMERA_ARR < <(cat /etc/octoprint_cameras | sed -n -e 's/^camera:\([[:graph:]]*\) .*/\1/p')
+        if [ "$addquit" == true ]; then
         CAMERA_ARR+=("Quit")
+        fi
     fi
 }
 
@@ -272,7 +276,7 @@ instance_status() {
     echo
     echo "${cyan}*******************************************${white}"
     get_instances false
-    get_cameras
+    get_cameras false
     #change this to reading /etc/octoprint_cameras
     #readarray -t cameras < <(ls -1 /etc/systemd/system/cam*.service 2> /dev/null | sed -n -e 's/^.*\/\(.*\).service/\1/p')
     #combine instances and cameras

--- a/util.sh
+++ b/util.sh
@@ -62,7 +62,7 @@ back_up() {
     echo "Creating backup of $INSTANCE...."
     sudo -p $user $OCTOEXEC --basedir /home/$user/.$INSTANCE plugins backup:backup --exclude timelapse
     sudo -p $user mkdir /home/$user/instance_backup 2>/dev/null
-    mv /home/$user/.$INSTANCE/data/backup/*.zip /home/$user/isntance_backup
+    mv /home/$user/.$INSTANCE/data/backup/*.zip /home/$user/instance_backup/
     echo "Zipped instance backup created in /home/$user/instance_backup"
 }
 


### PR DESCRIPTION
This PR replaces the octoprint_deploy backup files (gzipped tarballs) with the native OctoPrint backup. This will improve plugin restoration. In order to restore a backup, an instance with the same name must be created. Also, timelapse folder is ignored.