### PR TITLE
Restore mjpg-streamer as a webcam streamer option

### DIFF
--- a/cameras.sh
+++ b/cameras.sh
@@ -59,10 +59,7 @@ write_camera() {
     if [ "$STREAMER" == mjpg-streamer ]; then
         cat $SCRIPTDIR/octocam_mjpg.service | \
         sed -e "s/OCTOUSER/$OCTOUSER/" \
-        -e "s/OCTOCAM/$CAMDEVICE/" \
-        -e "s/RESOLUTION/$RESOLUTION/" \
-        -e "s/FRAMERATE/$FRAMERATE/" \
-        -e "s/CAMPORT/$CAMPORT/" > $SCRIPTDIR/cam${INUM}_$INSTANCE.service
+        -e "s/OCTOCAM/cam${INUM}_$INSTANCE/" > $SCRIPTDIR/$OUTFILE.service
     fi
     
     #ustreamer

--- a/octocam_mjpg.service
+++ b/octocam_mjpg.service
@@ -1,12 +1,13 @@
 [Unit]
-Description=the OctoPi(buntu) webcam daemon with the user specified config
+Description=the OctoPi(buntu) mjpg-streamer daemon with the user specified config
 After=network.online.target
 Wants=network.online.target
 
 [Service]
+EnvironmentFile=/etc/OCTOCAM.env
 User=OCTOUSER
 Environment="LD_LIBRARY_PATH=/home/OCTOUSER/mjpg-streamer"
-ExecStart=/home/OCTOUSER/mjpg-streamer/mjpg_streamer -i "input_uvc.so -d /dev/OCTOCAM -r RESOLUTION -f FRAMERATE -timeout 30" -o "output_http.so -p CAMPORT"
+ExecStart=/home/OCTOUSER/mjpg-streamer/mjpg_streamer -i "input_uvc.so -d ${DEVICE} -r ${RES} -f ${FRAMERATE} -timeout 30" -o "output_http.so -p ${PORT}"
 
 [Install]
 WantedBy=multi-user.target

--- a/prepare.sh
+++ b/prepare.sh
@@ -381,7 +381,7 @@ haproxy_install() {
 
 streamer_install() {
     PS3="${green}Which video streamer you would like to install?: ${white}"
-    options=("ustreamer (recommended)" "camera-streamer" "None/Skip")
+    options=("mjpeg-streamer" "ustreamer (recommended)" "camera-streamer" "None/Skip")
     select opt in "${options[@]}"
     do
         case $opt in


### PR DESCRIPTION
Looks like mjpg-streamer got disabled in commit 8d57a478 ("Rework (#94)").  Not sure if that was intentional.  This PR re-enables the option, and updates mjpg-streamer's  systemd itegration to be like that of ustreamer and camera-streamer.